### PR TITLE
Suppress variable noise in init.zsh

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -45,8 +45,11 @@ key_info=(
 
 # Bind the keys
 
-for key (${(s: :)key_info[ControlLeft]}) bindkey ${key} backward-word
-for key (${(s: :)key_info[ControlRight]}) bindkey ${key} forward-word
+function() {
+  local key
+  for key (${(s: :)key_info[ControlLeft]}) bindkey ${key} backward-word
+  for key (${(s: :)key_info[ControlRight]}) bindkey ${key} forward-word
+}
 
 [[ -n ${key_info[Home]} ]] && bindkey ${key_info[Home]} beginning-of-line
 [[ -n ${key_info[End]} ]] && bindkey ${key_info[End]} end-of-line

--- a/init.zsh
+++ b/init.zsh
@@ -45,7 +45,6 @@ key_info=(
 
 # Bind the keys
 
-local key
 for key (${(s: :)key_info[ControlLeft]}) bindkey ${key} backward-word
 for key (${(s: :)key_info[ControlRight]}) bindkey ${key} forward-word
 


### PR DESCRIPTION
This was causing noise in my terminal when sourced outside of zimfw.